### PR TITLE
Add MixpanelPublisher with multi-publisher support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 /vendor/
 composer.lock
 phpstan.neon
+
+# IDE files
+.idea/
+*.swp
+*.swo
+*~

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "require": {
         "php": "^8.2",
         "saloonphp/saloon": "^3.14",
-        "princejohnsantillan/reflect": "^1.1"
+        "princejohnsantillan/reflect": "^1.1",
+        "mixpanel/mixpanel-php" : "2.*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Book.php
+++ b/src/Book.php
@@ -12,7 +12,7 @@ class Book implements Contracts\Book
      */
     protected array $narratives = [];
 
-    protected bool $isPublished = false;
+    protected array $publishedPublishers = [];
 
     public function write(Narrative|ScopedNarrative $narrative): static
     {
@@ -53,15 +53,23 @@ class Book implements Contracts\Book
 
     public function publish(Publisher $publisher): void
     {
-        if ($this->isPublished) {
+        $publisherClass = get_class($publisher);
+        
+        if (isset($this->publishedPublishers[$publisherClass])) {
             return;
         }
 
-        $this->isPublished = $publisher->publish($this);
+        $this->publishedPublishers[$publisherClass] = $publisher->publish($this);
     }
 
     public function isPublished(): bool
     {
-        return $this->isPublished;
+        return !empty($this->publishedPublishers);
+    }
+
+    public function isPublishedBy(Publisher $publisher): bool
+    {
+        $publisherClass = get_class($publisher);
+        return isset($this->publishedPublishers[$publisherClass]);
     }
 }

--- a/src/NarrativeService.php
+++ b/src/NarrativeService.php
@@ -31,6 +31,11 @@ final class NarrativeService
         return $host;
     }
 
+    public function getConfig(): array
+    {
+        return $this->config;
+    }
+
     /**
      * @return array{name:string, url:string, token:string}
      */

--- a/src/Publishers/MixpanelPublisher.php
+++ b/src/Publishers/MixpanelPublisher.php
@@ -60,22 +60,14 @@ class MixpanelPublisher implements Publisher
                         $userId = $scopes['user_id'];
                         $mixpanel->identify(user_id: $userId);
                         
-                        // Use properties directly from scopes
                         if (isset($scopes['properties']) && is_array($scopes['properties'])) {
                             $mixpanel->people->setOnce($userId, $scopes['properties']);
                         }
                     }
 
-                    $eventProperties = array_merge(
-                        $narrative->values(),
-                        [
-                            'occurred_at' => $narrative->occurredAt(),
-                        ]
-                    );
-
                     $mixpanel->track(
                         event: $narrative->slug(),
-                        properties: $eventProperties
+                        properties: $narrative->values()
                     );
 
                 } catch (Exception $e) {

--- a/src/Publishers/MixpanelPublisher.php
+++ b/src/Publishers/MixpanelPublisher.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Narrative\Publishers;
+
+use Exception;
+use InvalidArgumentException;
+use Mixpanel;
+use Narrative\Contracts\Book;
+use Narrative\Contracts\Publisher;
+use Narrative\Exceptions\MissingArrayKeyException;
+use Narrative\NarrativeService;
+use Narrative\ScopedNarrative;
+
+use function Narrative\Support\array_value;
+
+class MixpanelPublisher implements Publisher
+{
+    protected ?Mixpanel $mixpanel = null;
+
+    public function __construct(
+        protected NarrativeService $narrativeService
+    ) {}
+
+    /**
+     * @throws MissingArrayKeyException
+     */
+    protected function getMixpanel(): Mixpanel
+    {
+        if ($this->mixpanel === null) {
+            $token = array_value($this->narrativeService->getConfig(), 'mix_panel_token');
+            
+            if (!$token) {
+                throw new InvalidArgumentException('Mixpanel token is required but not configured. Set mix_panel_token in config.');
+            }
+
+            $this->mixpanel = Mixpanel::getInstance(token: $token);
+        }
+
+        return $this->mixpanel;
+    }
+
+    /**
+     * @throws MissingArrayKeyException
+     */
+    public function publish(Book $book): bool
+    {
+        $mixpanel = $this->getMixpanel();
+
+        foreach ($book->storylines() as $storyline) {
+            foreach ($book->read($storyline) as $narrative) {
+                $scopes = null;
+
+                if ($narrative instanceof ScopedNarrative) {
+                    $scopes = $narrative->scopes;
+                    $narrative = $narrative->narrative;
+                }
+
+                try {
+                    if ($scopes && isset($scopes['user_id'])) {
+                        $userId = $scopes['user_id'];
+                        $mixpanel->identify(user_id: $userId);
+                        
+                        // Use properties directly from scopes
+                        if (isset($scopes['properties']) && is_array($scopes['properties'])) {
+                            $mixpanel->people->setOnce($userId, $scopes['properties']);
+                        }
+                    }
+
+                    $eventProperties = array_merge(
+                        $narrative->values(),
+                        [
+                            'occurred_at' => $narrative->occurredAt(),
+                        ]
+                    );
+
+                    $mixpanel->track(
+                        event: $narrative->slug(),
+                        properties: $eventProperties
+                    );
+
+                } catch (Exception $e) {
+                    error_log("Mixpanel tracking failed: " . $e->getMessage());
+                }
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Overview
Adds Mixpanel integration to the Narrative PHP SDK with support for multiple publishers.

## Key Features
- **MixpanelPublisher**: New publisher for sending events to Mixpanel
- **Multi-publisher support**: Scribe now supports multiple publishers simultaneously
- **User properties**: Automatic user identification and property setting via `setOnce`
- **Generic architecture**: Easy to add more publishers (REST, Mixpanel, etc.)

## Changes
- Added `MixpanelPublisher` class implementing the `Publisher` contract
- Updated `Scribe` to accept multiple publishers
- Modified `Book` to track publishing status per publisher
- Added `mix_panel_token` configuration option
- Updated `.gitignore` to exclude IDE files

## Usage
```php
$config = [
    'mix_panel_token' => 'your-token',
    'publishers' => [
        'mixpanel' => \Narrative\Publishers\MixpanelPublisher::class,
    ],
];

$scribe = Scribe::make($config);

$event = new UserRegister(/* ... */);
$scopedEvent = $event->scopedBy([
    'user_id' => 12345,
    'properties' => [
        '$name' => 'John Doe',
        '$email' => 'john@example.com',
    ]
]);

$scribe->write($scopedEvent);
$scribe->publish(); // Sends to all configured publishers
```

## Testing
- Verified user identification and property setting
- Confirmed event tracking works correctly